### PR TITLE
Prepare-0.1.1-release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ simphony-jyulb is hosted on github: https://github.com/simphony/simphony-jyulb
 
 Requirements
 ------------
- - `simphony-common`_ >= 0.0.1 
+ - `simphony-common`_ >= 0.1.1 
 
 .. _simphony-common: https://github.com/simphony/simphony-common
 

--- a/install_external.sh
+++ b/install_external.sh
@@ -2,5 +2,5 @@
 # install JYU-LB
 git clone https://github.com/simphony/JYU-LB.git
 cd JYU-LB
-make
+make -j 2
 ln -s  $(pwd)/bin/jyu_lb_isothermal3D.exe /usr/local/bin/jyu_lb_isothermal3D.exe

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jyu_engine',
-    version='0.1.1.dev0',
+    version='0.1.1',
     author='SimPhoNy FP7 European Project',
     description='Implementation of JYU-LB wrappers',
     packages=find_packages(),


### PR DESCRIPTION
This PR prepares for a bugfix release of the library that supports simphony 0.1.1 (probably 0.1.2)
